### PR TITLE
fix: convert repository owner to lowercase for GHCR tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - {uses: gacts/github-slug@v1, id: slug}
+      - name: Set lowercase repository owner
+        id: repo
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -90,7 +93,7 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           build-args: "APP_VERSION=${{ steps.slug.outputs.version }}"
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version-major }}
+            ghcr.io/${{ steps.repo.outputs.owner }}/${{ github.event.repository.name }}:latest
+            ghcr.io/${{ steps.repo.outputs.owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version }}
+            ghcr.io/${{ steps.repo.outputs.owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version-major }}.${{ steps.slug.outputs.version-minor }}
+            ghcr.io/${{ steps.repo.outputs.owner }}/${{ github.event.repository.name }}:${{ steps.slug.outputs.version-major }}


### PR DESCRIPTION
- Add step to convert repository owner to lowercase using tr
- Use lowercase owner in all GHCR image tags
- Fixes "repository name must be lowercase" error from GHCR
- GitHub Actions variables are case-sensitive, GHCR requires lowercase