### PR TITLE
fix: replace broken Renovate preset with working configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>tarampampam/.github//renovate/default",
+    "config:recommended",
     ":rebaseStalePrs"
-  ]
+  ],
+  "enabledManagers": [
+    "gomod",
+    "dockerfile",
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "description": "Group Go dependencies",
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ],
+  "golang": {
+    "minimumReleaseAge": "3 days"
+  },
+  "schedule": ["before 6am on Monday"],
+  "timezone": "UTC"
 }


### PR DESCRIPTION
The external preset from tarampampam/.github was returning 404 errors,
preventing Renovate from detecting dependencies.

Changes:
- Replaced external preset with config:recommended
- Explicitly enabled gomod, dockerfile, and github-actions managers
- Added package rules to group updates by type
- Configured weekly schedule and minimum release age for stability