### PR TITLE
feat: pin all dependencies to exact versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,16 +9,24 @@
     "dockerfile",
     "github-actions"
   ],
+  "rangeStrategy": "pin",
   "packageRules": [
     {
-      "description": "Group Go dependencies",
+      "description": "Pin Go dependencies to exact versions",
       "matchManagers": ["gomod"],
-      "groupName": "Go dependencies"
+      "groupName": "Go dependencies",
+      "rangeStrategy": "pin"
     },
     {
-      "description": "Group GitHub Actions updates",
+      "description": "Pin GitHub Actions to exact commit SHAs",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "pinDigests": true
+    },
+    {
+      "description": "Pin Docker images to exact digests",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
     }
   ],
   "golang": {


### PR DESCRIPTION
Added pinning strategy for all dependency types:
- Go modules: pin to exact versions (no ranges)
- GitHub Actions: pin to commit SHAs for reproducibility
- Docker images: pin to digests for immutability

This ensures reproducible builds and prevents unexpected updates.